### PR TITLE
fixed role ID

### DIFF
--- a/src/tools/BotTools.py
+++ b/src/tools/BotTools.py
@@ -33,10 +33,10 @@ class DBServer:
             raise DatabaseException("unable to find the server")
         info = cur.fetchone()
         db.close()
-        self.mjrole = info[1]
+        self.mjrole = info[1] if info[1] is not None else "-1"
         self.prefix = info[2]
         self.keepingrole = info[3]
-        self.adminrole = info[4]
+        self.adminrole = info[4] if info[4] is not None else "-1"
 
     def togglekeeprole(self):
         self.keepingrole = not self.keepingrole


### PR DESCRIPTION
Bug fix on role ID for admin and/or MJ role when it is missing for a server.

BEFORE : raise error due to theese ID were `None` value

AFTER : ID is set by default to `-1` when getting it, so no roles will be found, and no error will be raised