### PR TITLE
Removing Pillow depency and disabling Battle Map feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,21 +405,21 @@ Alias : `getmp`
 #### Map commands
 - `/map` (MJ only and JDR channel only) <br/>
 Display the world map of Terae
-- `/map show <width> <height> [depth]` (MJ only and JDR channel only) <br/>
+- ~~`/map show <width> <height> [depth]` (MJ only and JDR channel only)~~ **(DISABLED)** <br/>
 Show the local fight map displaying all tokens and effects registered for the current game. Only effects affecting this depth (Z axis) given will be displayed, if not given, depth is considered equal to 0.
-- `/map clear` (MJ only and JDR channel only) <br/>
+- ~~`/map clear` (MJ only and JDR channel only)~~ **(DISABLED)** <br/>
 Clear all tokens and effects on your local fight map <br/>
 Aliases : `clr`, `reset`
-- `/map (token|tk) add <name>` (MJ only and JDR channel only) <br/>
+- ~~`/map (token|tk) add <name>` (MJ only and JDR channel only)~~ **(DISABLED)** <br/>
 Add a token on your local fight map, a token represents an entity that can be moved and can generate area of effects (AOE). When created, the token will automatically put on the origin (0;0;0) of the map. Use token move command to move it. <br/>
 Alias : `+`
-- `/map (token|tk) remove <name>` (MJ only and JDR channel only) <br/>
+- ~~`/map (token|tk) remove <name>` (MJ only and JDR channel only)~~ **(DISABLED)** <br/>
 Remove a token from your local fight map <br/>
 Aliases : `rm`, `delete`, `del`, `map token -`, `-`
-- `/map token move <name> <dx> <dy> [dz]` (MJ only and JDR channel only) <br/>
+- ~~`/map token move <name> <dx> <dy> [dz]` (MJ only and JDR channel only)~~ **(DISABLED)** <br/>
 Move a token in the direction given by the vector (dx;dy;dz). If not given dz is equal to 0 <br/>
 Alias : `mv`
-- `/map effect add <tkname> <dx> <dy> <dz> <shape> [parameters]` (MJ only and JDR channel only) <br/>
+- ~~`/map effect add <tkname> <dx> <dy> <dz> <shape> [parameters]` (MJ only and JDR channel only)~~ **(DISABLED)** <br/>
 Register an area of effect for a given token. shape must be one of the following : `circle`,`sphere`,`line`,`rect`,`cube`,`conic`. Each of theese shape have their own parameters, some of them have to be given for the generation. <br/>
 The parameters format is a list of key/value separated by space characters. The key/value pair should be as following : `key=value`.
 Alias : `+` <br/>
@@ -435,7 +435,7 @@ conic : <lengths> [orientation (default=0)]
     lengths -> list of lengths separated with '-' symbol, the first value is the closest line from the origin and the last the farthest line from the origin (example : 1-3-5). DO NOT USE SPACE BETWEEN LENGTHS VALUES.
     orientation -> the value in degrees (following counter-clockwise rotation), can only be one of the following : 0, 90, 180 or 270
 ```
-- `/map effect clear <tkname>` (MJ only and JDR channel only) <br/>
+- ~~`/map effect clear <tkname>` (MJ only and JDR channel only)~~ **(DISABLED)** <br/>
 Clear all effects for the given token <br/>
 Aliases : `clr`, `reset`
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 asyncio==3.4.3
 discord.py==1.5.0
-Pillow==9.0.0
+#Pillow==9.0.0
 psycopg2-binary==2.8.1
 PyNaCl==1.3.0
 requests==2.25.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 asyncio==3.4.3
 discord.py==1.5.0
-Pillow==8.1.1
+Pillow==9.0.0
 psycopg2-binary==2.8.1
 PyNaCl==1.3.0
 requests==2.25.1

--- a/src/cogs/jdr/Maps.py
+++ b/src/cogs/jdr/Maps.py
@@ -22,7 +22,7 @@ from src.tools.BotTools import *
 from discord.ext import commands
 import logging,asyncio
 import discord
-from src.tools.mapmanager import *
+# from src.tools.mapmanager import *
 from src.utils.converters import *
 import typing
 
@@ -43,7 +43,7 @@ class Maps(commands.Cog):
 
     @commands.check(check_chanmj)
     @commands.cooldown(1,60,commands.BucketType.channel)
-    @map.command(name="show")
+    @map.command(name="show", enabled=False)
     async def map_show(self,ctx,width: int, height: int, depth: typing.Optional[int] = 0):
         """**GM/MJ only**
         Display your game battle map"""
@@ -54,7 +54,7 @@ class Maps(commands.Cog):
 
     @commands.check(check_chanmj)
     @commands.cooldown(1,30,commands.BucketType.channel)
-    @map.command(name="clear",aliases=["reset","clr"])
+    @map.command(name="clear", aliases=["reset","clr"], enabled=False)
     async def map_clear(self,ctx):
         """**GM/MJ only**
         Clear all tokens and effects on your game battle map"""
@@ -64,11 +64,11 @@ class Maps(commands.Cog):
         await ctx.message.channel.send(data.lang["mapreset"])
 
     @commands.check(check_chanmj)
-    @map.group(name="token",invoke_without_command=False,aliases=["tk"])
+    @map.group(name="token", invoke_without_command=False, aliases=["tk"], enabled=False)
     async def map_token(self,ctx): pass
 
-    @map_token.command(name="add",aliases=["+"])
-    async def map_token_add(self,ctx,tkname):
+    @map_token.command(name="add",aliases=["+"], enabled=False)
+    async def map_token_add(self, ctx, tkname):
         """**GM/MJ only**
         Add a token on your game battle map"""
         data = GenericCommandParameters(ctx)
@@ -77,8 +77,8 @@ class Maps(commands.Cog):
         self.logger.log(logging.DEBUG+1,"token %s registered in channel %d on server %d",tkname,ctx.message.channel.id,ctx.message.guild.id)
         await ctx.message.channel.send(data.lang["tokenadd"].format(tk.name))
 
-    @map_token.command(name="remove",aliases=["rm","-","delete","del"])
-    async def map_token_remove(self,ctx,tk: MapTokenConverter):
+    @map_token.command(name="remove", aliases=["rm","-","delete","del"], enabled=False)
+    async def map_token_remove(self, ctx, tk: MapTokenConverter):
         """**GM/MJ only**
         Remove a token and all its effects associated from your game battle map"""
         if tk is not None:
@@ -87,7 +87,7 @@ class Maps(commands.Cog):
             self.logger.log(logging.DEBUG+1,"token %s removed in channel %d on server %d",tk.name,ctx.message.channel.id,ctx.message.guild.id)
             await ctx.message.channel.send(data.lang["tokenrm"].format(tk.name))
 
-    @map_token.command(name="move",aliases=["mv"])
+    @map_token.command(name="move", aliases=["mv"], enabled=False)
     async def map_token_move(self,ctx,tk: MapTokenConverter, dx: int, dy: int, dz: typing.Optional[int] = 0):
         """**GM/MJ only**
         Move a token in the given direction"""
@@ -98,10 +98,10 @@ class Maps(commands.Cog):
             await ctx.message.channel.send(data.lang["tokenmove"].format(tk.name,tk.x,tk.y,tk.z))
 
     @commands.check(check_chanmj)
-    @map.group(name="effect",invoke_without_command=False)
+    @map.group(name="effect", invoke_without_command=False, enabled=False)
     async def map_effect(self,ctx): pass
 
-    @map_effect.command(name="add",aliases=["+"])
+    @map_effect.command(name="add", aliases=["+"], enabled=False)
     async def map_effect_add(self,ctx,tk: MapTokenConverter, dx: int, dy: int, dz: int, shape: ShapeConverter,*,params: MapEffectParameterConverter):
         """**GM/MJ only**
         Register an area of effect for a given token. shape must be one of the following : `circle`,`sphere`,`line`,`rect`,`cube`,`conic`.
@@ -129,7 +129,7 @@ class Maps(commands.Cog):
             await ctx.message.channel.send(data.lang["effect_register"].format(tk.name))
 
     @commands.cooldown(3,5,commands.BucketType.channel)
-    @map_effect.command(name="clear",aliases=["reset","clr"])
+    @map_effect.command(name="clear", aliases=["reset","clr"], enabled=False)
     async def map_effect_clear(self,ctx,tk: MapTokenConverter):
         """**GM/MJ only**
         Clear all effects from the given token"""

--- a/src/tools/CharacterUtils.py
+++ b/src/tools/CharacterUtils.py
@@ -226,7 +226,7 @@ def retrieveOrganization(orgid):
 
 def isOrganizationHidden(orgname):
     db = Database()
-    cur = db.execute("SELECT hidden FROM organization WHERE nom = %(org)s", org=orgname)
+    cur = db.execute("SELECT hidden FROM organizations WHERE nom = %(org)s", org=orgname)
     if cur is None:
         db.close()
         return False

--- a/src/tools/mapmanager.py
+++ b/src/tools/mapmanager.py
@@ -18,7 +18,7 @@
 ##    along with this program. If not, see <http://www.gnu.org/licenses/>
 
 from enum import Enum
-from PIL import Image,ImageDraw,ImageFont
+# from PIL import Image,ImageDraw,ImageFont
 from src.utils.DatabaseManager import *
 from src.utils.config import *
 import io,asyncio,discord

--- a/src/utils/converters.py
+++ b/src/utils/converters.py
@@ -23,7 +23,7 @@ from discord.ext import commands
 from src.tools.Character import *
 from src.tools.CharacterUtils import *
 from src.utils.checks import GenericCommandParameters
-from src.tools.mapmanager import *
+# from src.tools.mapmanager import *
 from src.tools.parsingdice import DiceType
 
 class CharacterConverter(commands.Converter):


### PR DESCRIPTION
Battle Map feature is not used by anyone due to a big complexity on its use. Pillow is only used for those features and has too many vulnerabilities making mandatory to update TtgcBot too often. Due to this and as we are planning to integrate battle maps in other projects, we are disabling permanently all battle map features on TtgcBot.